### PR TITLE
Enable ESLint no-console rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     "prefer-const": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-this-alias": "off"
+    "@typescript-eslint/no-this-alias": "off",
+    "no-console": ["error", {"allow": ["warn", "error"]}]
   }
 };


### PR DESCRIPTION
This should hopefully prevent any more pesky `console.log`s from sneaking into PRs.