### PR TITLE
Reference/resolve variables by ID instead of name

### DIFF
--- a/src/BlockInput.ts
+++ b/src/BlockInput.ts
@@ -41,12 +41,18 @@ export interface Broadcast extends Base {
 
 export interface Variable extends Base {
   type: "variable";
-  value: string;
+  value: {
+    id: string;
+    name: string;
+  };
 }
 
 export interface List extends Base {
   type: "list";
-  value: string;
+  value: {
+    id: string;
+    name: string;
+  };
 }
 
 export interface Block extends Base {

--- a/src/Target.ts
+++ b/src/Target.ts
@@ -25,9 +25,21 @@ export default class Target {
   }
 
   public get blocks(): Block[] {
-    return this.scripts.flatMap(script => {
-      return script.blocks.flatMap(block => block.blocks);
-    });
+    return this.scripts.flatMap(script =>
+      script.blocks.flatMap(recursive));
+
+    function recursive(block: Block): Block[] {
+      return [block, ...Object.values(block.inputs).flatMap(input => {
+        switch (input.type) {
+          case "block":
+            return recursive(input.value);
+          case "blocks":
+            return input.value.flatMap(recursive);
+          default:
+            return [];
+        }
+      })];
+    }
   }
 
   public setName(name: string): void {

--- a/src/Target.ts
+++ b/src/Target.ts
@@ -25,20 +25,31 @@ export default class Target {
   }
 
   public get blocks(): Block[] {
-    return this.scripts.flatMap(script =>
-      script.blocks.flatMap(recursive));
+    const collector = [];
 
-    function recursive(block: Block): Block[] {
-      return [block, ...Object.values(block.inputs).flatMap(input => {
+    for (const script of this.scripts) {
+      for (const block of script.blocks) {
+        recursive(block);
+      }
+    }
+
+    return collector;
+
+    function recursive(block: Block) {
+      collector.push(block);
+
+      for (const input of Object.values(block.inputs)) {
         switch (input.type) {
           case "block":
-            return recursive(input.value);
+            recursive(input.value);
+            break;
           case "blocks":
-            return input.value.flatMap(recursive);
-          default:
-            return [];
+            for (const block of input.value) {
+              recursive(block);
+            }
+            break;
         }
-      })];
+      }
     }
   }
 

--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -168,7 +168,7 @@ export default class Stage extends StageBase {
     yield* this.askAndWait(this.loudness);
     yield* this.askAndWait(this.timer);
     yield* this.askAndWait(this.stage.costumeNumber);
-    yield* this.askAndWait(this.stage.vars[\\"CloudVar\\"]);
+    yield* this.askAndWait(this.stage.vars.CloudVar);
     yield* this.askAndWait(new Date().getDay() + 1);
     yield* this.askAndWait(
       ((new Date().getTime() - new Date(2000, 0, 1)) / 1000 / 60 +

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -1,6 +1,6 @@
 import Project from "../../Project";
 import Script from "../../Script";
-import Block from "../../Block";
+import Block, { BlockBase } from "../../Block";
 import * as BlockInput from "../../BlockInput";
 import { OpCode } from "../../OpCode";
 
@@ -981,10 +981,14 @@ export default function toLeopard(
       for (const script of checkTarget.scripts) {
         for (const block of script.blocks) {
           if (block.opcode === OpCode.data_showvariable || block.opcode === OpCode.data_hidevariable) {
-            shownWatchers.add(block.inputs.VARIABLE.value.id);
+            shownWatchers.add(
+              (block as BlockBase<OpCode.data_showvariable, { VARIABLE: BlockInput.Variable }>).inputs.VARIABLE.value.id
+            );
           }
           if (block.opcode === OpCode.data_showlist || block.opcode === OpCode.data_hidelist) {
-            shownWatchers.add(block.inputs.LIST.value.id);
+            shownWatchers.add(
+              (block as BlockBase<OpCode.data_showlist, { LIST: BlockInput.List }>).inputs.LIST.value.id
+            );
           }
         }
       }

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -980,11 +980,11 @@ export default function toLeopard(
     for (const checkTarget of targetsToCheckForShowBlocks) {
       for (const script of checkTarget.scripts) {
         for (const block of script.blocks) {
-          if (block.opcode === OpCode.data_showvariable) {
-            shownWatchers.add(block.inputs.VARIABLE.value);
+          if (block.opcode === OpCode.data_showvariable || block.opcode === OpCode.data_hidevariable) {
+            shownWatchers.add(block.inputs.VARIABLE.value.id);
           }
-          if (block.opcode === OpCode.data_showlist) {
-            shownWatchers.add(block.inputs.LIST.value);
+          if (block.opcode === OpCode.data_showlist || block.opcode === OpCode.data_hidelist) {
+            shownWatchers.add(block.inputs.LIST.value.id);
           }
         }
       }

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -978,18 +978,16 @@ export default function toLeopard(
       targetsToCheckForShowBlocks = [target];
     }
     for (const checkTarget of targetsToCheckForShowBlocks) {
-      for (const script of checkTarget.scripts) {
-        for (const block of script.blocks) {
-          if (block.opcode === OpCode.data_showvariable || block.opcode === OpCode.data_hidevariable) {
-            shownWatchers.add(
-              (block as BlockBase<OpCode.data_showvariable, { VARIABLE: BlockInput.Variable }>).inputs.VARIABLE.value.id
-            );
-          }
-          if (block.opcode === OpCode.data_showlist || block.opcode === OpCode.data_hidelist) {
-            shownWatchers.add(
-              (block as BlockBase<OpCode.data_showlist, { LIST: BlockInput.List }>).inputs.LIST.value.id
-            );
-          }
+      for (const block of checkTarget.blocks) {
+        if (block.opcode === OpCode.data_showvariable || block.opcode === OpCode.data_hidevariable) {
+          shownWatchers.add(
+            (block as BlockBase<OpCode.data_showvariable, { VARIABLE: BlockInput.Variable }>).inputs.VARIABLE.value.id
+          );
+        }
+        if (block.opcode === OpCode.data_showlist || block.opcode === OpCode.data_hidelist) {
+          shownWatchers.add(
+            (block as BlockBase<OpCode.data_showlist, { LIST: BlockInput.List }>).inputs.LIST.value.id
+          );
         }
       }
     }

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -980,14 +980,10 @@ export default function toLeopard(
     for (const checkTarget of targetsToCheckForShowBlocks) {
       for (const block of checkTarget.blocks) {
         if (block.opcode === OpCode.data_showvariable || block.opcode === OpCode.data_hidevariable) {
-          shownWatchers.add(
-            (block as BlockBase<OpCode.data_showvariable, { VARIABLE: BlockInput.Variable }>).inputs.VARIABLE.value.id
-          );
+          shownWatchers.add(block.inputs.VARIABLE.value.id);
         }
         if (block.opcode === OpCode.data_showlist || block.opcode === OpCode.data_hidelist) {
-          shownWatchers.add(
-            (block as BlockBase<OpCode.data_showlist, { LIST: BlockInput.List }>).inputs.LIST.value.id
-          );
+          shownWatchers.add(block.inputs.LIST.value.id);
         }
       }
     }
@@ -1055,9 +1051,9 @@ export default function toLeopard(
             .join("\n")}
 
           ${[...target.variables, ...target.lists]
-            .map(variable => [variable, variableNameMap[variable.id]] as [Variable | List, string])
-            .filter(([variable]) => variable.visible || shownWatchers.has(variable.id))
-            .map(([variable, newName]) => {
+            .filter(variable => variable.visible || shownWatchers.has(variable.id))
+            .map(variable => {
+              const newName = variableNameMap[variable.id];
               return `this.watchers.${newName} = new Watcher({
               label: ${JSON.stringify((target.isStage ? "" : `${target.name}: `) + variable.name)},
               style: ${JSON.stringify(

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -458,7 +458,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
     }
 
     for (const varList of [target.variables, target.lists]) {
-      for (let i = 0, variable; variable = varList[i]; i++) {
+      for (let i = 0, variable; (variable = varList[i]); i++) {
         if (variable.visible) {
           continue;
         }

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -463,7 +463,6 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
 
         varList.splice(i, 1);
         i--;
-        continue;
       }
     }
   }

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -433,8 +433,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
   for (const target of [project.stage, ...project.sprites]) {
     let relevantBlocks: Block[] = null;
     if (target === project.stage) {
-      relevantBlocks = [project.stage, ...project.sprites]
-        .flatMap(target => target.blocks);
+      relevantBlocks = project.stage.blocks.concat(project.sprites.flatMap(sprite => sprite.blocks));
     } else {
       relevantBlocks = target.blocks;
     }

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -216,7 +216,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
                 type: "block",
                 value: new BlockBase({
                   opcode: OpCode.data_variable,
-                  inputs: { VARIABLE: { type: "variable", value: value[1] } },
+                  inputs: { VARIABLE: { type: "variable", value: { id: value[2], name: value[1] } } },
                   parent: blockId
                 }) as Block
               });
@@ -227,7 +227,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
                 type: "block",
                 value: new BlockBase({
                   opcode: OpCode.data_listcontents,
-                  inputs: { LIST: { type: "list", value: value[1] } },
+                  inputs: { LIST: { type: "list", value: { id: value[2], name: value[1] } } },
                   parent: blockId
                 }) as Block
               });
@@ -268,7 +268,11 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
       let result = {};
       for (const [fieldName, values] of Object.entries(fields)) {
         const type = sb3.fieldTypeMap[opcode][fieldName];
-        result[fieldName] = { type, value: values[0] };
+        if (fieldName === "VARIABLE" || fieldName === "LIST") {
+          result[fieldName] = { type, value: { id: values[1], name: values[0] } };
+        } else {
+          result[fieldName] = { type, value: values[0] };
+        }
       }
 
       return result;

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -431,7 +431,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
   // Run an extra pass on variables (and lists). Only those which are actually
   // referenced in blocks or monitors should be kept.
   for (const target of [project.stage, ...project.sprites]) {
-    let relevantBlocks: Array<Block> = null;
+    let relevantBlocks: Block[] = null;
     if (target === project.stage) {
       relevantBlocks = [project.stage, ...project.sprites]
         .flatMap(target => target.blocks);

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -433,7 +433,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
   for (const target of [project.stage, ...project.sprites]) {
     let relevantBlocks: Block[] = null;
     if (target === project.stage) {
-      relevantBlocks = project.stage.blocks.concat(project.sprites.flatMap(sprite => sprite.blocks));
+      relevantBlocks = target.blocks.concat(project.sprites.flatMap(sprite => sprite.blocks));
     } else {
       relevantBlocks = target.blocks;
     }

--- a/src/io/sb3/toSb3.ts
+++ b/src/io/sb3/toSb3.ts
@@ -93,19 +93,20 @@ export default function toSb3(options: Partial<ToSb3Options> = {}): ToSb3Output 
     for (const key of Object.keys(fieldEntries)) {
       const input = inputs[key];
       // Fields are stored as a plain [value, id?] pair.
+      let valueOrName;
       let id: string;
       switch (input.type) {
         case "variable":
-          id = getVariableId(input.value, target, stage);
-          break;
         case "list":
-          id = getListId(input.value, target, stage);
+          valueOrName = input.value.name;
+          id = input.value.id;
           break;
         default:
+          valueOrName = input.value;
           id = null;
           break;
       }
-      fields[key] = [input.value, id];
+      fields[key] = [valueOrName, id];
     }
 
     return fields;
@@ -397,14 +398,12 @@ export default function toSb3(options: Partial<ToSb3Options> = {}): ToSb3Output 
 
           switch (input.value.opcode) {
             case OpCode.data_variable: {
-              const variableName = input.value.inputs.VARIABLE.value;
-              const variableId = getVariableId(variableName, target, stage);
+              const { id: variableId, name: variableName } = input.value.inputs.VARIABLE.value;
               obscuringBlockValue = [BIS.VAR_PRIMITIVE, variableName, variableId];
               break;
             }
             case OpCode.data_listcontents: {
-              const listName = input.value.inputs.LIST.value;
-              const listId = getListId(listName, target, stage);
+              const { id: listId, name: listName } = input.value.inputs.LIST.value;
               obscuringBlockValue = [BIS.LIST_PRIMITIVE, listName, listId];
               break;
             }

--- a/src/io/sb3/toSb3.ts
+++ b/src/io/sb3/toSb3.ts
@@ -880,7 +880,7 @@ export default function toSb3(options: Partial<ToSb3Options> = {}): ToSb3Output 
     // etc into the structures Scratch 3.0 expects.
 
     function mapToIdObject<Entry extends { id: string }, ReturnType>(
-      values: Array<Entry>,
+      values: Entry[],
       fn: (x: Entry) => ReturnType
     ): { [key: string]: ReturnType } {
       // Map an Array of objects with an "id` property

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -424,7 +424,7 @@ export default function toScratchblocks(
 
       // data -------------------------------------------------------- //
       case OpCode.data_variable:
-        return `(${block.inputs.VARIABLE.value} :: variables)`;
+        return `(${block.inputs.VARIABLE.value.name} :: variables)`;
       case OpCode.data_setvariableto:
         return `set ${i("VARIABLE")} to ${i("VALUE")}`;
       case OpCode.data_changevariableby:
@@ -434,7 +434,7 @@ export default function toScratchblocks(
       case OpCode.data_hidevariable:
         return `hide variable ${i("VARIABLE")}`;
       case OpCode.data_listcontents:
-        return `(${block.inputs.LIST.value} :: list)`;
+        return `(${block.inputs.LIST.value.name} :: list)`;
       case OpCode.data_addtolist:
         return `add ${i("ITEM")} to ${i("LIST")}`;
       case OpCode.data_deleteoflist:

--- a/src/io/scratchblocks/toScratchblocks.ts
+++ b/src/io/scratchblocks/toScratchblocks.ts
@@ -61,6 +61,8 @@ export default function toScratchblocks(
 
       case "variable":
       case "list":
+        return `[${escape(inp.value.name)} v]`;
+
       case "rotationStyle":
       case "scrollAlignment":
       case "stopMenu":


### PR DESCRIPTION
**This is a major change to the way sb-edit reads and serializes variables.**

- Fixes #85 
- Fixes #86 

This PR changes `BlockInput.Variable` and `BlockInput.List` so their value is a pair of values (in an object), `{ id: string, name: string }`, instead of one value (just the name). The `fromSb3` deserializing code pulls from the IDs in the actual sb3 file, and all serializing code is updated to respect the new format — most notably, this resolves issues in `toLeopard` surrounding multiple variables existing of different IDs but the same name.

The last commit, af5280ba271a184aa0a218ab7b306a7f2f31377c, adds a final pass to `fromSb3` deserialization so that variables which are never referenced in blocks nor shown as monitors are totally wiped from the code — this is a bit of a presumptuous decision and means sb3 -> sb3 conversion is explicitly *not* a one-to-one conversion, but I think that's an okay precedent to set, and it seemed to make more sense to run this pass on input data in `fromSb3` rather than preprocessing in `toLeopard`. (In the future, I'm considering separating this chunk of code out so it's one of a modular set of "processing" prefabs including other automatic code optimizations, but that would be for a separate PR.)

@adroitwhiz I added you as a PR reviewer, but feel free to pass if you aren't interested or don't currently have the time!
