### PR TITLE
toLeopard: Serialize initial rotation style

### DIFF
--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -291,7 +291,10 @@ export default class Stage extends StageBase {
   </body>
 </html>
 ",
-  "index.js": "import { Project } from \\"https://unpkg.com/leopard@^1/dist/index.esm.js\\";
+  "index.js": "import {
+  Project,
+  Sprite
+} from \\"https://unpkg.com/leopard@^1/dist/index.esm.js\\";
 
 import Stage from \\"./Stage/Stage.js\\";
 import Abby from \\"./Abby/Abby.js\\";
@@ -303,6 +306,7 @@ const sprites = {
     x: -36,
     y: -23,
     direction: 90,
+    rotationStyle: Sprite.RotationStyle.ALL_AROUND,
     costumeNumber: 1,
     size: 100,
     visible: true,

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -1885,7 +1885,7 @@ export default function toLeopard(
       </html>
     `,
     "index.js": `
-      import { Project } from ${JSON.stringify(toLeopardJS({ from: "index" }))};
+      import { Project, Sprite } from ${JSON.stringify(toLeopardJS({ from: "index" }))};
 
       ${[project.stage, ...project.sprites]
         .map(
@@ -1900,15 +1900,24 @@ export default function toLeopard(
         ${project.sprites
           .map(
             sprite =>
-              `${sprite.name}: new ${sprite.name}(${JSON.stringify({
+              `${sprite.name}: new ${sprite.name}({${Object.entries({
                 x: sprite.x,
                 y: sprite.y,
                 direction: sprite.direction,
+                rotationStyle: `Sprite.RotationStyle.${
+                  {
+                    normal: "ALL_AROUND",
+                    leftRight: "LEFT_RIGHT",
+                    none: "DONT_ROTATE"
+                  }[sprite.rotationStyle]
+                }`,
                 costumeNumber: sprite.costumeNumber + 1,
                 size: sprite.size,
                 visible: sprite.visible,
                 layerOrder: sprite.layerOrder
-              })})`
+              })
+                .map(([key, value]) => `${key}:${value}`)
+                .join(",")}})`
           )
           .join(",\n")}
       };


### PR DESCRIPTION
This PR makes `toLeopard` represent the initial rotation style (which is already represented in IR and loaded by `fromSb3`).

- Resolves #117.

Implementation notes:

* Although we convert *to* the same `Sprite.RotationStyle.ALL_AROUND`/etc value both in block and initial-state serialization, we're mapping *from* different values. (sb3 block inputs like "all around" or "don't rotate" in the former, sb-edit values like "normal" or "none" in the latter.) Accordingly, it wasn't appropriate to introduce a constant mapping reused by both — but it's definitely a bit weird that sb-edit represent the input for "set rotation style" with the same values it uses for a sprite's initial rotation style.
* I had to change the way we stringify sprites to support including an arbitrary expression in the initial-state object. The important part is that each key maps to an already "stringified" value, i.e. the exact expression that will be inserted, instead of implicitly stringifying all values with `JSON.stringify` on the whole object.
* The output `index.js` file needs to import `Sprite` from Leopard's library file now, as well as `Project` (as it did before).

Tested with this project: https://scratch.mit.edu/projects/877138925/ 

And a "boring" project that makes sure the "set rotation style" blocks are still working.

Requested both @PullJosh and @adroitwhiz for review but an OK would be fine from either of you, this isn't a big pull request and improves Scratch compatibility for Leopard in a user-visible way!