### PR TITLE
toLeopard: Code style cleanup for blockToJS & related functions

### DIFF
--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -542,6 +542,16 @@ export default function toLeopard(
       return `this.sprites[${JSON.stringify(targetNameMap[input.value])}]`;
     }
 
+    function colorInputToJS(input: BlockInput.Color | BlockInput.Block): string {
+      if (input.type === "color") {
+        const { r, g, b } = input.value;
+        return `Color.rgb(${r}, ${g}, ${b})`;
+      } else {
+        const num = inputToJS(input, InputShape.Number);
+        return `Color.num(${num})`;
+      }
+    }
+
     function inputToJS(input: BlockInput.Any, desiredInputShape: InputShape): string {
       // TODO: Right now, inputs can be completely undefined if imported from
       // the .sb3 format (because sb3 is weird). This little check will replace
@@ -1405,13 +1415,8 @@ export default function toLeopard(
         case OpCode.sensing_touchingcolor: {
           satisfiesInputShape = InputShape.Boolean;
 
-          if (block.inputs.COLOR.type === "color") {
-            const { r, g, b } = block.inputs.COLOR.value;
-            blockSource = `this.touching(Color.rgb(${r}, ${g}, ${b}))`;
-          } else {
-            const num = inputToJS(block.inputs.COLOR, InputShape.Number);
-            blockSource = `this.touching(Color.num(${num}))`;
-          }
+          const color = colorInputToJS(block.inputs.COLOR);
+          blockSource = `this.touching(${color})`;
 
           break;
         }
@@ -1419,25 +1424,8 @@ export default function toLeopard(
         case OpCode.sensing_coloristouchingcolor: {
           satisfiesInputShape = InputShape.Boolean;
 
-          let color1: string;
-          let color2: string;
-
-          if (block.inputs.COLOR.type === "color") {
-            const { r, g, b } = block.inputs.COLOR.value;
-            color1 = `Color.rgb(${r}, ${g}, ${b})`;
-          } else {
-            const num = inputToJS(block.inputs.COLOR, InputShape.Number);
-            color1 = `Color.num(${num})`;
-          }
-
-          if (block.inputs.COLOR2.type === "color") {
-            const { r, g, b } = block.inputs.COLOR2.value;
-            color2 = `Color.rgb(${r}, ${g}, ${b})`;
-          } else {
-            const num = inputToJS(block.inputs.COLOR, InputShape.Number);
-            color2 = `Color.num(${num})`;
-          }
-
+          const color1 = colorInputToJS(block.inputs.COLOR);
+          const color2 = colorInputToJS(block.inputs.COLOR2);
           blockSource = `this.colorTouching((${color1}), (${color2}))`;
 
           break;
@@ -2289,13 +2277,8 @@ export default function toLeopard(
         case OpCode.pen_setPenColorToColor: {
           satisfiesInputShape = InputShape.Stack;
 
-          if (block.inputs.COLOR.type === "color") {
-            const { r, g, b } = block.inputs.COLOR.value;
-            blockSource = `this.penColor = Color.rgb(${r}, ${g}, ${b})`;
-          } else {
-            const num = inputToJS(block.inputs.COLOR, InputShape.Number);
-            blockSource = `this.penColor = Color.num(${num})`;
-          }
+          const color = colorInputToJS(block.inputs.COLOR);
+          blockSource = `this.penColor = (${color})`;
 
           break;
         }

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -489,7 +489,7 @@ export default function toLeopard(
 
     function increase(leftSide: string, input: BlockInput.Any, allowIncrementDecrement: boolean): string {
       const n = parseNumber(input);
-      if (n === null) {
+      if (typeof n !== "number") {
         return `${leftSide} += ${inputToJS(input, InputShape.Number)}`;
       }
 
@@ -506,7 +506,7 @@ export default function toLeopard(
 
     function decrease(leftSide: string, input: BlockInput.Any, allowIncrementDecrement: boolean) {
       const n = parseNumber(input);
-      if (n === null) {
+      if (typeof n !== "number") {
         return `${leftSide} -= ${inputToJS(input, InputShape.Number)}`;
       }
 
@@ -1469,7 +1469,8 @@ export default function toLeopard(
         case OpCode.sensing_askandwait: {
           satisfiesInputShape = InputShape.Stack;
 
-          blockSource = `yield* this.askAndWait(${inputToJS(block.inputs.QUESTION, InputShape.Any)})`;
+          const question = inputToJS(block.inputs.QUESTION, InputShape.Any);
+          blockSource = `yield* this.askAndWait(${question})`;
 
           break;
         }
@@ -1485,7 +1486,8 @@ export default function toLeopard(
         case OpCode.sensing_keypressed: {
           satisfiesInputShape = InputShape.Boolean;
 
-          blockSource = `this.keyPressed(${inputToJS(block.inputs.KEY_OPTION, InputShape.String)})`;
+          const key = inputToJS(block.inputs.KEY_OPTION, InputShape.String);
+          blockSource = `this.keyPressed(${key})`;
 
           break;
         }


### PR DESCRIPTION
This pull request cleans up the code style contained by and surrounding `blockToJS` in a number of fairly high-impact ways, which together make it far easier to incrementally edit block definitions, compare one block to another, and generally read and understand the codebase. See individual commits; in summary:

* Calls to `inputToJS` are basically never inlined as part of the `blockSource` template strings anymore; instead, they're defined in temporary variables, each on its own line, immediately above. This gets rid of the question of "is it worth it *enough* to store this input on a variable?" (always yes) and avoids some really brutal line breaking on particularly long template strings.
* Every `case OpCode.category_op` now gets a proper block scope, i.e. `case OpCode.foo: { ... }`. This is to help with the new variables above, but also just makes the code style more consistent. (This pattern is reflected in other switch-cases in the same file, purely for consistency.)
* Every `case OpCode.category_op` is divided into three sections: one which sets `satisfiesInputShape`, one which sets `blockSource` (including the related `inputToJS` calls), and one which is just the final `break;` at the end. This is mostly aesthetic, but it does lend a visual consistency across both those cases which are simpler and more complex.
* Helper functions `spriteInputToJS` and `colorInputToJS` isolate commonly reused logic/patterns into helper functions. This doesn't actually change any behavior at all - all uses of `spriteInputToJS` followed exactly that behavior, etc. But it means there's a lot less logical volume being dedicated to this unnecessarily duplicate behavior, so block definitions are more focused on just what's unique about them.
* Order of operations (i.e. deeper nested reporters being evaluated first) is enforced very simply by wrapping *every* instance of a reporter block in parentheses... as part of the layering function, `inputToJS`! This means we don't have to use loads and loads and *loads* of redundant parentheses, rather inconsistently, in block definitions. Accordingly, any explicitly written parentheses that remain (very few) actually carry significance, and don't get lost in the noise.
* Some minor tweaks are made to code logic to clarify be a bit easier to parse, or more consistently written across similar block definitions. Some examples:
  * We always define `let x` and `let y` instead of `let coords`.
  * We always prefer switch/case when checking for one or more menu option values.
  * We always prefer checking `typeof parseNumber(input) !== "number"` instead of `parseNumber(input) === null`.
  * The logic for `operator_add` and `operator_subtract` is written with fewer nested cases and duplicate lines.
  * The section at the end of `blockToJS` which matches against `desiredInputShape` now uses a switch/case rather than a bunch of if-else cases, since it logically lines up with a switch/case/case/case/default quite well.

This PR basically doesn't change any behavior, apart from a few logic tidiness mentioned above, and the change to how order of operations is expressed. Since the latter has always been collaped by prettier, this doesn't affect sb-edit output at all — only how the code is expressed.

A neat way of reviewing this would probably be to view the diff in the "side by side" / [split view appearance](https://github.com/leopard-js/sb-edit/pull/124/files?diff=split&w=0) (rather than with additions and subtractions all in one column).