### PR TITLE
toLeopard: Fix touching edge/mouse block

### DIFF
--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -1401,12 +1401,12 @@ export default function toLeopard(
           let target: string;
           switch (block.inputs.TOUCHINGOBJECTMENU.value) {
             case "_mouse_": {
-              target = "mouse";
+              target = JSON.stringify("mouse");
               break;
             }
 
             case "_edge_": {
-              target = "edge";
+              target = JSON.stringify("edge");
               break;
             }
 


### PR DESCRIPTION
We broke this [in December](https://github.com/leopard-js/sb-edit/pull/124/commits/c527dda5da5aa46add80e898affba2317770178d#diff-53bcd905a44c89be07db03a8803fe1d8caa6511fe69441ec095f627eafcc5dd4R1381), and since, then the "touching mouse" and "touching edge" boolean blocks have been serialized to:

```js
this.touching(mouse)
this.touching(edge)

// instead of
this.touching("mouse")
this.touching("edge")
```

This PR fixes that!

I'm using `JSON.stringify` instead of just e.g. `"\"mouse\""` because it conveys the same meaning as other general uses, including e.g. [`spriteInputToJS`](https://github.com/towerofnix/sb-edit/blob/c527dda5da5aa46add80e898affba2317770178d/src/io/leopard/toLeopard.ts#L541-L543) and [`increase`](https://github.com/towerofnix/sb-edit/blob/c527dda5da5aa46add80e898affba2317770178d/src/io/leopard/toLeopard.ts#L500-L504).