### PR TITLE
Create CLI that can convert sb3 to leopard or leopard-zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,64 @@ sb-edit can also be used to modify Scratch projects. A few things you can/will b
 | Scripts             | 🕒 Planned | 🕒 Planned | 🕒 Planned |
 | Costumes and sounds | 🕒 Planned | 🕒 Planned | 🕒 Planned |
 
+## CLI Examples
+
+To use the sb-edit CLI, first install it globally using the following command:
+
+```
+$ npm i -g sb-edit
+```
+
+### Convert .sb3 project to Leopard
+
+```
+$ sb-edit --input path/to/project.sb3 --output path/to/output-folder
+```
+
+### Convert .sb3 project to Leopard .zip
+
+```
+$ sb-edit --input path/to/project.sb3 --output path/to/output-folder.zip
+```
+
+## Code Examples
+
+### Import an .sb3 file in Node
+
+```js
+const { Project } = require("sb-edit");
+const fs = require("fs");
+const path = require("path");
+
+const file = fs.readFileSync(path.join(__dirname, "myProject.sb3"));
+const project = await Project.fromSb3(file);
+
+console.log(project);
+```
+
+### Export an .sb3 file in Node
+
+```js
+const { Project } = require("sb-edit");
+const fs = require("fs");
+const path = require("path");
+
+const project = /* Get yourself a `Project`... */;
+
+const saveLocation = path.join(__dirname, "myProject.sb3");
+fs.writeFileSync(saveLocation, Buffer.from(await project.toSb3()));
+
+// `project` is now saved at ./myProject.sb3
+```
+
+### Get Leopard code for project
+
+```js
+const project = /* Get yourself a `Project`... */;
+
+console.log(project.toLeopard({ printWidth: 100 })); // Optionally pass a Prettier config object!
+```
+
 ## Development
 
 If you want to help develop the sb-edit package, you'll need to follow these steps:
@@ -71,42 +129,4 @@ And finally, make sure everything is pretty:
 ```shell
 > cd sb-edit
 > npm run format # Format code to look nice with Prettier
-```
-
-## Code Examples
-
-### Import an .sb3 file in Node
-
-```js
-const { Project } = require("sb-edit");
-const fs = require("fs");
-const path = require("path");
-
-const file = fs.readFileSync(path.join(__dirname, "myProject.sb3"));
-const project = await Project.fromSb3(file);
-
-console.log(project);
-```
-
-### Export an .sb3 file in Node
-
-```js
-const { Project } = require("sb-edit");
-const fs = require("fs");
-const path = require("path");
-
-const project = /* Get yourself a `Project`... */;
-
-const saveLocation = path.join(__dirname, "myProject.sb3");
-fs.writeFileSync(saveLocation, Buffer.from(await project.toSb3()));
-
-// `project` is now saved at ./myProject.sb3
-```
-
-### Get Leopard code for project
-
-```js
-const project = /* Get yourself a `Project`... */;
-
-console.log(project.toLeopard({ printWidth: 100 })); // Optionally pass a Prettier config object!
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
         "jszip": "^3.10.1",
-        "prettier": "^2.8.8",
-        "wcwidth": "^1.0.1"
+        "prettier": "^2.8.8"
       },
       "bin": {
         "sb-edit": "lib/cli/index.js"
@@ -23,7 +22,6 @@
         "@types/jszip": "^3.1.6",
         "@types/node": "^20.12.7",
         "@types/prettier": "^2.7.3",
-        "@types/wcwidth": "^1.0.2",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "eslint": "^8.56.0",
@@ -980,6 +978,27 @@
         }
       }
     },
+    "node_modules/@jest/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1095,6 +1114,15 @@
         }
       }
     },
+    "node_modules/@jest/reporters/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
@@ -1109,6 +1137,31 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1442,12 +1495,6 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
-    "node_modules/@types/wcwidth": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/wcwidth/-/wcwidth-1.0.2.tgz",
-      "integrity": "sha512-flVlIrTSL6Z0RS2/IQYP0sUDajwuZ21FQAdOjzitcraVAarBFBwBpixtvxMno56vzFvLAbaGZEhkmMVYmWVUQA==",
-      "dev": true
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.22",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
@@ -1720,15 +1767,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2040,12 +2078,25 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
-        "node": ">=0.8"
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/co": {
@@ -2184,17 +2235,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-newline": {
@@ -2407,6 +2447,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -3620,6 +3681,40 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-watcher/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
@@ -4561,19 +4656,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4588,7 +4670,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4870,14 +4961,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4908,6 +4991,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,13 @@
       "version": "0.13.14",
       "license": "MIT",
       "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^12.0.0",
         "jszip": "^3.10.1",
         "prettier": "^2.8.8"
+      },
+      "bin": {
+        "sb-edit": "lib/cli/index.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -1718,7 +1723,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1969,7 +1973,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2045,7 +2048,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2056,8 +2058,15 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2769,7 +2778,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4595,7 +4603,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "chalk": "^4.1.2",
         "commander": "^12.0.0",
         "jszip": "^3.10.1",
-        "prettier": "^2.8.8"
+        "prettier": "^2.8.8",
+        "wcwidth": "^1.0.1"
       },
       "bin": {
         "sb-edit": "lib/cli/index.js"
@@ -20,7 +21,9 @@
       "devDependencies": {
         "@types/jest": "^29.5.11",
         "@types/jszip": "^3.1.6",
+        "@types/node": "^20.12.7",
         "@types/prettier": "^2.7.3",
+        "@types/wcwidth": "^1.0.2",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "eslint": "^8.56.0",
@@ -1413,10 +1416,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "12.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
-      "dev": true
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
@@ -1434,6 +1440,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/wcwidth": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/wcwidth/-/wcwidth-1.0.2.tgz",
+      "integrity": "sha512-flVlIrTSL6Z0RS2/IQYP0sUDajwuZ21FQAdOjzitcraVAarBFBwBpixtvxMno56vzFvLAbaGZEhkmMVYmWVUQA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -2028,6 +2040,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2164,6 +2184,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-newline": {
@@ -4770,6 +4801,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -4831,6 +4868,14 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -43,15 +43,13 @@
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "jszip": "^3.10.1",
-    "prettier": "^2.8.8",
-    "wcwidth": "^1.0.1"
+    "prettier": "^2.8.8"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/jszip": "^3.1.6",
     "@types/node": "^20.12.7",
     "@types/prettier": "^2.7.3",
-    "@types/wcwidth": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "files": [
     "lib/**/*"
   ],
+  "bin": {
+    "sb-edit": "lib/cli/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
@@ -37,6 +40,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
+    "chalk": "^4.1.2",
+    "commander": "^12.0.0",
     "jszip": "^3.10.1",
     "prettier": "^2.8.8"
   },

--- a/package.json
+++ b/package.json
@@ -43,12 +43,15 @@
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "jszip": "^3.10.1",
-    "prettier": "^2.8.8"
+    "prettier": "^2.8.8",
+    "wcwidth": "^1.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/jszip": "^3.1.6",
+    "@types/node": "^20.12.7",
     "@types/prettier": "^2.7.3",
+    "@types/wcwidth": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "eslint": "^8.56.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,248 @@
+#! /usr/bin/env node
+
+import { Command, Option } from "commander";
+import Project from "../Project";
+
+import * as fs from "fs";
+import { resolve } from "path";
+import * as JSZip from "jszip";
+
+import * as chalk from "chalk";
+
+const program = new Command();
+
+program.name("sb-edit").description("CLI for manipulating Scratch projects");
+
+program
+  .requiredOption("-i, --input <path>", "The path to the input project")
+  .addOption(new Option("-it, --input-type <type>", "The type of input file").choices(["sb3"]))
+  .requiredOption("-o, --output <path>", "The path to the output project")
+  .addOption(new Option("-ot, --output-type <type>", "The type of output file").choices(["leopard", "leopard-zip"]));
+
+program.parse();
+
+const options: {
+  input: string;
+  inputType: "sb3";
+  output: string;
+  outputType: "leopard" | "leopard-zip";
+} = program.opts();
+
+let { input, inputType, output, outputType } = options;
+
+// Infer input type
+if (inputType === undefined) {
+  inputType = "sb3";
+}
+
+// Infer output type
+if (outputType === undefined) {
+  if (output.endsWith(".zip")) {
+    outputType = "leopard-zip";
+  } else {
+    outputType = "leopard";
+  }
+}
+
+async function run() {
+  class StepError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "StepError";
+      Object.setPrototypeOf(this, StepError.prototype);
+    }
+  }
+
+  let stepNumber = 1;
+  async function writeStep<ReturnType>(description: string, fn: () => ReturnType | Promise<ReturnType>) {
+    process.stdout.write(chalk.gray`  ${stepNumber++}. ${description}`);
+    let value: ReturnType;
+    try {
+      value = await fn();
+      process.stdout.write(chalk.bold.green(" Done.\n"));
+    } catch (err) {
+      if (err instanceof StepError) {
+        process.stdout.write(chalk.bold.red(` ${err.message}`));
+        process.stdout.write(chalk.red(`\n\nProject conversion failed.\n`));
+      } else {
+        process.stdout.write(chalk.bold.red` An unknown error occurred.`);
+        process.stderr.write(chalk.red`\n\n${err}\n`);
+      }
+      process.exit(1);
+    }
+    return value;
+  }
+
+  process.stdout.write(chalk.underline.gray`Converting project:\n`);
+
+  const fullInputPath = resolve(process.cwd(), input);
+
+  const project = await writeStep(
+    `${chalk.bold("Importing")} ${inputType} project from path ${chalk.white(fullInputPath)}.`,
+    async () => {
+      let file: Buffer;
+      try {
+        file = fs.readFileSync(fullInputPath);
+      } catch (err) {
+        if (err instanceof Object && "code" in err) {
+          switch (err.code) {
+            case "ENOENT":
+              throw new StepError("File not found.");
+            case "EISDIR":
+              throw new StepError("Input path is a directory but should be a file.");
+          }
+        }
+        throw err;
+      }
+      const project = await Project.fromSb3(file);
+      return project;
+    }
+  );
+
+  switch (outputType) {
+    case "leopard": {
+      const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, () => {
+        const leopard = project.toLeopard();
+        return leopard;
+      });
+
+      const fullOutputPath = resolve(process.cwd(), output);
+
+      await writeStep(`${chalk.bold("Exporting")} project to directory ${chalk.white(fullOutputPath)}.`, () => {
+        // First, make sure the output path is an empty directory (create it if it doesn't exist)
+        let existingFiles: string[];
+        try {
+          existingFiles = fs.readdirSync(fullOutputPath);
+        } catch (err) {
+          if (err instanceof Object && "code" in err) {
+            switch (err.code) {
+              case "ENOENT":
+                // Directory does not exist, create it
+                fs.mkdirSync(output, { recursive: true });
+                existingFiles = [];
+                break;
+              case "ENOTDIR":
+                throw new StepError("Output path is a file, not a directory.");
+              default:
+                throw err;
+            }
+          } else {
+            throw err;
+          }
+        }
+
+        if (existingFiles.length > 0) {
+          throw new StepError("Output directory is not empty.");
+        }
+
+        // Write the files
+        for (const [filename, contents] of Object.entries(leopard)) {
+          // Create directories as needed
+          fs.mkdirSync(resolve(fullOutputPath, filename, ".."), { recursive: true });
+
+          // Write the file
+          fs.writeFileSync(resolve(fullOutputPath, filename), contents);
+        }
+
+        for (const target of [project.stage, ...project.sprites]) {
+          for (const costume of target.costumes) {
+            const filename = `${target.name}/costumes/${costume.name}.${costume.ext}`;
+            const asset = Buffer.from(costume.asset as ArrayBuffer);
+            fs.mkdirSync(resolve(fullOutputPath, filename, ".."), { recursive: true });
+            fs.writeFileSync(resolve(fullOutputPath, filename), asset);
+          }
+
+          for (const sound of target.sounds) {
+            const filename = `${target.name}/sounds/${sound.name}.${sound.ext}`;
+            const asset = Buffer.from(sound.asset as ArrayBuffer);
+            fs.mkdirSync(resolve(fullOutputPath, filename, ".."), { recursive: true });
+            fs.writeFileSync(resolve(fullOutputPath, filename), asset);
+          }
+        }
+      });
+
+      process.stdout.write(chalk.green`\nProject exported to Leopard format.`);
+      process.stdout.write(chalk.gray` Files written to ${chalk.white(fullOutputPath)}\n\n`);
+      process.stdout.write(
+        chalkBox([
+          { str: "To preview the project, run:" },
+          { str: `$ ${chalk.white`cd ${output}`}`, length: 5 + output.length },
+          { str: `$ ${chalk.white`npx vite`}`, length: 10 }
+        ])
+      );
+      break;
+    }
+    case "leopard-zip": {
+      const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, () => {
+        const leopard = project.toLeopard();
+        return leopard;
+      });
+
+      const fullOutputPath = resolve(process.cwd(), output);
+
+      await writeStep(`${chalk.bold("Exporting")} project to zip file ${chalk.white(fullOutputPath)}.`, () => {
+        // First, check if file name is already taken
+        try {
+          fs.accessSync(fullOutputPath);
+          throw new StepError("Output file already exists.");
+        } catch (err) {
+          if (err instanceof Object && "code" in err && err.code === "ENOENT") {
+            // File does not exist, good
+          } else {
+            throw err;
+          }
+        }
+
+        const zip = new JSZip();
+
+        for (const [filename, contents] of Object.entries(leopard)) {
+          zip.file(filename, contents);
+        }
+
+        for (const target of [project.stage, ...project.sprites]) {
+          for (const costume of target.costumes) {
+            const filename = `${target.name}/costumes/${costume.name}.${costume.ext}`;
+            const asset = Buffer.from(costume.asset as ArrayBuffer);
+            zip.file(filename, asset);
+          }
+
+          for (const sound of target.sounds) {
+            const filename = `${target.name}/sounds/${sound.name}.${sound.ext}`;
+            const asset = Buffer.from(sound.asset as ArrayBuffer);
+            zip.file(filename, asset);
+          }
+        }
+
+        zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }).pipe(fs.createWriteStream(fullOutputPath));
+      });
+
+      break;
+    }
+  }
+}
+
+function chalkBox(lines: { str: string; length?: number }[]): string {
+  const lengths = lines.map(line => line.length ?? line.str.length);
+  const boxInnerWidth = Math.max(...lengths) + 2;
+
+  let outputStr = "";
+  outputStr += chalk.bold.blue`╔${"═".repeat(boxInnerWidth)}╗`;
+  for (const line of lines) {
+    const length = line.length ?? line.str.length;
+    outputStr += chalk.bold.blue`\n║ `;
+    outputStr += chalk.gray(line.str);
+    outputStr += " ".repeat(boxInnerWidth - length - 2);
+    outputStr += chalk.bold.blue` ║`;
+  }
+  outputStr += chalk.bold.blue(`\n╚${"═".repeat(boxInnerWidth)}╝\n`);
+
+  return outputStr;
+}
+
+run().catch(err => {
+  if (err instanceof Error) {
+    console.error(err.stack);
+  }
+
+  process.exit(1);
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import { Command, Option } from "commander";
 import Project from "../Project";
+import { createWriteStream } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import JSZip from "jszip";
@@ -270,9 +271,7 @@ async function run() {
           }
         }
 
-        zip
-          .generateNodeStream({ type: "nodebuffer", streamFiles: true })
-          .pipe((await fs.open(fullOutputPath)).createWriteStream());
+        zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }).pipe(createWriteStream(fullOutputPath));
       });
 
       break;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,13 +1,12 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 import { Command, Option } from "commander";
 import Project from "../Project";
-
-import * as fs from "fs";
-import { resolve } from "path";
-import * as JSZip from "jszip";
-
-import * as chalk from "chalk";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import JSZip from "jszip";
+import chalk from "chalk";
+import wcwidth from "wcwidth";
 
 const program = new Command();
 
@@ -30,17 +29,62 @@ const options: {
 
 let { input, inputType, output, outputType } = options;
 
-// Infer input type
-if (inputType === undefined) {
-  inputType = "sb3";
+class InferTypeError extends Error {
+  constructor(public readonly stage: "input" | "output", message: string) {
+    super(message);
+    this.name = "InferTypeError";
+    Object.setPrototypeOf(this, InferTypeError.prototype);
+  }
 }
 
-// Infer output type
-if (outputType === undefined) {
-  if (output.endsWith(".zip")) {
-    outputType = "leopard-zip";
-  } else {
-    outputType = "leopard";
+try {
+  // Infer input type
+  if (inputType === undefined) {
+    if (input.endsWith(".sb3")) {
+      inputType = "sb3";
+    } else if (input.endsWith(".sb") || input.endsWith(".sprite")) {
+      throw new InferTypeError("input", "Scratch 1.4 input projects are not currently supported.");
+    } else if (input.endsWith(".sb2") || input.endsWith(".sprite2")) {
+      throw new InferTypeError("input", "Scratch 2.0 input projects are not currently supported.");
+    } else if (input.endsWith(".sprite3")) {
+      throw new InferTypeError("input", "Scratch 3.0 sprite inputs are not currently supported.");
+    } else {
+      throw new InferTypeError("input", "Could not infer input file type.");
+    }
+  }
+
+  // Infer output type
+  if (outputType === undefined) {
+    if (output.endsWith(".zip")) {
+      outputType = "leopard-zip";
+    } else if (output.endsWith(".sb")) {
+      throw new InferTypeError("output", "Scratch 1.4 output projects are not currently supported.");
+    } else if (output.endsWith(".sb2")) {
+      throw new InferTypeError("output", "Scratch 2.0 output projects are not currently supported.");
+    } else if (output.endsWith(".sb3")) {
+      throw new InferTypeError("output", "Scratch 3.0 output projects are not currently supported.");
+    } else if (path.extname(output) === "") {
+      outputType = "leopard";
+    } else {
+      throw new InferTypeError("output", "Could not infer output type.");
+    }
+  }
+} catch (err) {
+  if (err instanceof InferTypeError) {
+    process.stderr.write(chalk.red`${err.message}`);
+    switch (err.stage) {
+      case "input":
+        process.stderr.write(
+          chalk.gray` Please choose a different input file. (Or, if your file is actually of a supported type and just has an unusual file name, specify the correct type with --input-type.)\n`
+        );
+        break;
+      case "output":
+        process.stderr.write(
+          chalk.gray` Please choose a different output path or specify the desired output type with --output-type.\n`
+        );
+        break;
+    }
+    process.exit(1);
   }
 }
 
@@ -55,17 +99,20 @@ async function run() {
 
   let stepNumber = 1;
   async function writeStep<ReturnType>(description: string, fn: () => ReturnType | Promise<ReturnType>) {
-    process.stdout.write(chalk.gray`  ${stepNumber++}. ${description}`);
+    const thisStepNumber = stepNumber++;
+    process.stdout.write(chalk.gray`  ${thisStepNumber}. ${description}`);
     let value: ReturnType;
     try {
       value = await fn();
       process.stdout.write(chalk.bold.green(" Done.\n"));
     } catch (err) {
       if (err instanceof StepError) {
-        process.stdout.write(chalk.bold.red(` ${err.message}`));
+        process.stdout.write(chalk.bold.red(`\n${" ".repeat(4 + String(thisStepNumber).length)}${err.message}`));
         process.stdout.write(chalk.red(`\n\nProject conversion failed.\n`));
       } else {
-        process.stdout.write(chalk.bold.red` An unknown error occurred.`);
+        process.stdout.write(
+          chalk.bold.red`\n${" ".repeat(4 + String(thisStepNumber).length)}An unknown error occurred.`
+        );
         process.stderr.write(chalk.red`\n\n${err}\n`);
       }
       process.exit(1);
@@ -75,14 +122,14 @@ async function run() {
 
   process.stdout.write(chalk.underline.gray`Converting project:\n`);
 
-  const fullInputPath = resolve(process.cwd(), input);
+  const fullInputPath = path.resolve(process.cwd(), input);
 
   const project = await writeStep(
     `${chalk.bold("Importing")} ${inputType} project from path ${chalk.white(fullInputPath)}.`,
     async () => {
       let file: Buffer;
       try {
-        file = fs.readFileSync(fullInputPath);
+        file = await fs.readFile(fullInputPath);
       } catch (err) {
         if (err instanceof Object && "code" in err) {
           switch (err.code) {
@@ -94,7 +141,14 @@ async function run() {
         }
         throw err;
       }
-      const project = await Project.fromSb3(file);
+
+      let project: Project;
+      switch (inputType) {
+        case "sb3": {
+          project = await Project.fromSb3(file);
+          break;
+        }
+      }
       return project;
     }
   );
@@ -102,23 +156,22 @@ async function run() {
   switch (outputType) {
     case "leopard": {
       const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, () => {
-        const leopard = project.toLeopard();
-        return leopard;
+        return project.toLeopard();
       });
 
-      const fullOutputPath = resolve(process.cwd(), output);
+      const fullOutputPath = path.resolve(process.cwd(), output);
 
-      await writeStep(`${chalk.bold("Exporting")} project to directory ${chalk.white(fullOutputPath)}.`, () => {
+      await writeStep(`${chalk.bold("Exporting")} project to directory ${chalk.white(fullOutputPath)}.`, async () => {
         // First, make sure the output path is an empty directory (create it if it doesn't exist)
         let existingFiles: string[];
         try {
-          existingFiles = fs.readdirSync(fullOutputPath);
+          existingFiles = await fs.readdir(fullOutputPath);
         } catch (err) {
           if (err instanceof Object && "code" in err) {
             switch (err.code) {
               case "ENOENT":
                 // Directory does not exist, create it
-                fs.mkdirSync(output, { recursive: true });
+                await fs.mkdir(output, { recursive: true });
                 existingFiles = [];
                 break;
               case "ENOTDIR":
@@ -137,26 +190,30 @@ async function run() {
 
         // Write the files
         for (const [filename, contents] of Object.entries(leopard)) {
+          const filePath = path.resolve(fullOutputPath, filename);
+
           // Create directories as needed
-          fs.mkdirSync(resolve(fullOutputPath, filename, ".."), { recursive: true });
+          await fs.mkdir(path.dirname(filePath), { recursive: true });
 
           // Write the file
-          fs.writeFileSync(resolve(fullOutputPath, filename), contents);
+          await fs.writeFile(filePath, contents);
         }
 
         for (const target of [project.stage, ...project.sprites]) {
+          const costumeDir = path.join(target.name, "costumes");
           for (const costume of target.costumes) {
-            const filename = `${target.name}/costumes/${costume.name}.${costume.ext}`;
+            const filename = path.join(costumeDir, `${costume.name}.${costume.ext}`);
             const asset = Buffer.from(costume.asset as ArrayBuffer);
-            fs.mkdirSync(resolve(fullOutputPath, filename, ".."), { recursive: true });
-            fs.writeFileSync(resolve(fullOutputPath, filename), asset);
+            await fs.mkdir(path.resolve(fullOutputPath, filename, ".."), { recursive: true });
+            await fs.writeFile(path.resolve(fullOutputPath, filename), asset);
           }
 
+          const soundDir = path.join(target.name, "sounds");
           for (const sound of target.sounds) {
-            const filename = `${target.name}/sounds/${sound.name}.${sound.ext}`;
+            const filename = path.join(soundDir, `${sound.name}.${sound.ext}`);
             const asset = Buffer.from(sound.asset as ArrayBuffer);
-            fs.mkdirSync(resolve(fullOutputPath, filename, ".."), { recursive: true });
-            fs.writeFileSync(resolve(fullOutputPath, filename), asset);
+            await fs.mkdir(path.resolve(fullOutputPath, filename, ".."), { recursive: true });
+            await fs.writeFile(path.resolve(fullOutputPath, filename), asset);
           }
         }
       });
@@ -165,9 +222,9 @@ async function run() {
       process.stdout.write(chalk.gray` Files written to ${chalk.white(fullOutputPath)}\n\n`);
       process.stdout.write(
         chalkBox([
-          { str: "To preview the project, run:" },
-          { str: `$ ${chalk.white`cd ${output}`}`, length: 5 + output.length },
-          { str: `$ ${chalk.white`npx vite`}`, length: 10 }
+          "To preview the project, run:",
+          `$ ${chalk.white`cd ${output}`}`,
+          `$ ${chalk.white`npx vite`} # or serve with any HTTP server`
         ])
       );
       break;
@@ -178,12 +235,12 @@ async function run() {
         return leopard;
       });
 
-      const fullOutputPath = resolve(process.cwd(), output);
+      const fullOutputPath = path.resolve(process.cwd(), output);
 
-      await writeStep(`${chalk.bold("Exporting")} project to zip file ${chalk.white(fullOutputPath)}.`, () => {
+      await writeStep(`${chalk.bold("Exporting")} project to zip file ${chalk.white(fullOutputPath)}.`, async () => {
         // First, check if file name is already taken
         try {
-          fs.accessSync(fullOutputPath);
+          await fs.access(fullOutputPath);
           throw new StepError("Output file already exists.");
         } catch (err) {
           if (err instanceof Object && "code" in err && err.code === "ENOENT") {
@@ -213,7 +270,9 @@ async function run() {
           }
         }
 
-        zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }).pipe(fs.createWriteStream(fullOutputPath));
+        zip
+          .generateNodeStream({ type: "nodebuffer", streamFiles: true })
+          .pipe((await fs.open(fullOutputPath)).createWriteStream());
       });
 
       break;
@@ -221,16 +280,16 @@ async function run() {
   }
 }
 
-function chalkBox(lines: { str: string; length?: number }[]): string {
-  const lengths = lines.map(line => line.length ?? line.str.length);
+function chalkBox(lines: string[]): string {
+  const lengths = lines.map(line => wcwidth(line));
   const boxInnerWidth = Math.max(...lengths) + 2;
 
   let outputStr = "";
   outputStr += chalk.bold.blue`╔${"═".repeat(boxInnerWidth)}╗`;
   for (const line of lines) {
-    const length = line.length ?? line.str.length;
+    const length = wcwidth(line);
     outputStr += chalk.bold.blue`\n║ `;
-    outputStr += chalk.gray(line.str);
+    outputStr += chalk.gray(line);
     outputStr += " ".repeat(boxInnerWidth - length - 2);
     outputStr += chalk.bold.blue` ║`;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
Closes #128. **Allows importing a .sb3 file and generating a leopard folder or zip directly from the CLI.** I haven't implemented .sb3 output yet for the sake of time/effort. (And because .sb3 is currently the only allowed input method so it would be mostly useless.)

Example output:
![Screenshot of sb-edit CLI output](https://github.com/leopard-js/sb-edit/assets/5458180/784329ba-e0c3-4c51-95cd-b4c46cfaeba6)

I also did my best to make the errors look nice:
![Screenshot of sb-edit CLI error](https://github.com/leopard-js/sb-edit/assets/5458180/44748223-536b-4e51-a9ff-36def6bddb87)
