### PR TITLE
Add -t, --trace CLI option; enable TypeScript source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "outDir": "./lib",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "sourceMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "./lib",
     "strict": true,
     "esModuleInterop": true,
-    "sourceMap": true
+    "inlineSourceMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
This PR adds a `-t` / `--trace` CLI option which enables showing the log for unknown errors. It's not necessarily meant to be used by users, moreso just a convenience for us debugging problems.

It also enables source map generation in tsconfig.json. I believe these would be included in the NPM package, which I think is standard practice. Node.js (when running sb-edit) doesn't actually do anything with source maps without providing the `--enable-source-maps` option, typically via an environment variable.

<img width="832" alt="sb-edit output with Node.js --enable-source-maps and sb-edit -t. The message reads, An unknown error occurred. The JavaScript details are shown below. This is a bug, please share the project you used on: URL to sb-edit issues. Then there is a blank line and the full error trace, which includes paths to the TypeScript source files." src="https://github.com/leopard-js/sb-edit/assets/9948030/ba580ff3-83d9-427b-9529-36a4ff1f1c17">

<img width="835" alt="Same as above but no --enable-source-maps. Everything is the same except you get generated lib files in the stack trace, instead of source TypeScript files." src="https://github.com/leopard-js/sb-edit/assets/9948030/a7847cb4-b1ae-4646-b27e-3307f7d27774">

<img width="838" alt="Typical sb-edit output without any special options. The message is the same and you still see the JavaScript description of the error, but no stack trace." src="https://github.com/leopard-js/sb-edit/assets/9948030/2eb53a02-f56c-426f-874f-4fca72ca5e1c">
