### PR TITLE
fromSb3: Fix loading undefined sb3Block.next

### DIFF
--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -292,7 +292,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
     }
   }
 
-  function blockWithNext(blockId: string, parentId: string | undefined = undefined): Block[] {
+  function blockWithNext(blockId: string, parentId?: string): Block[] {
     const sb3Block = blocks[blockId];
     const block = new BlockBase({
       opcode: sb3Block.opcode,
@@ -302,7 +302,7 @@ function getBlockScript(blocks: { [key: string]: sb3.Block }) {
       next: sb3Block.next ?? undefined
     }) as Block;
     let next: Block[] = [];
-    if (sb3Block.next !== null) {
+    if (typeof sb3Block.next === "string") {
       next = blockWithNext(sb3Block.next, blockId);
     }
     return [block, ...next];

--- a/src/io/sb3/fromSb3.ts
+++ b/src/io/sb3/fromSb3.ts
@@ -391,6 +391,8 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
       extractSounds(target, options.getAsset)
     ]);
 
+    const getScript = getBlockScript(target.blocks);
+
     return {
       name: target.name,
       isStage: target.isStage,
@@ -402,7 +404,7 @@ export async function fromSb3JSON(json: sb3.ProjectJSON, options: { getAsset: Ge
         .map(
           ([id, block]) =>
             new Script({
-              blocks: getBlockScript(target.blocks)(id),
+              blocks: getScript(id),
               x: block.x,
               y: block.y
             })

--- a/src/io/sb3/interfaces.ts
+++ b/src/io/sb3/interfaces.ts
@@ -77,8 +77,8 @@ type MutationFor<Op extends OpCode> = Op extends OpCode.procedures_prototype
 export interface Block<Op extends OpCode = OpCode> {
   opcode: Op;
 
-  next: string | null;
-  parent: string | null;
+  next?: string | null;
+  parent?: string | null;
 
   inputs: {
     [key: string]: BlockInput;


### PR DESCRIPTION
Development:

- Resolves #143 
- Towards #141 (specific project)

See #143 for some technical discussion.

Best to view the commits separately, as they are independent changes, though they affect the same area of code.

* Makes undefined (missing) `next` on blocks in a project.json not crash `fromSb3`. This may be a omission by a minifier used in the demo project, rather than something Scratch itself will ever serialize, though Scratch handles deserializing undefined `next` just fine, so sb-edit should too.
* Improves some code clarity. `blockWithNext` is sometimes called without its `parentId` argument so we just make it `parentId?: string` instead of `parentId: string | undefined`. And `getBlockScript`, previously called once for each script in a target, is now called just once for each target, because `getBlockScript` does not care which script you're about to get, and is structured to make all scripts available. (It's a currying function, so now we use it like one!)

Tested manually with the project shared in #141, [WebOMatic!](https://scratch.mit.edu/projects/1025698237/).