### PR TITLE
Add "--leopard-url" CLI option

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,10 @@ program
   .addOption(new Option("-it, --input-type <type>", "The type of input file").choices(["sb3"]))
   .requiredOption("-o, --output <path>", "The path to the output project")
   .addOption(new Option("-ot, --output-type <type>", "The type of output file").choices(["leopard", "leopard-zip"]))
-  .addOption(new Option("-t, --trace", "Show a detailed error trace"));
+  .addOption(new Option("-t, --trace", "Show a detailed error trace"))
+  .addOption(
+    new Option("--leopard-url <url>", "The URL to use for Leopard").default("https://unpkg.com/leopard@^1/dist/")
+  );
 
 program.parse();
 
@@ -27,6 +30,7 @@ const options: {
   output: string;
   outputType: "leopard" | "leopard-zip";
   trace: boolean | undefined;
+  leopardUrl: string;
 } = program.opts();
 
 let { input, inputType, output, outputType } = options;
@@ -164,7 +168,24 @@ async function run() {
   );
 
   function toLeopard() {
-    return project.toLeopard();
+    const { leopardUrl: leopardURL } = options;
+
+    let fileJS = "index.esm.js";
+    let fileCSS = "index.min.css";
+
+    let leopardJSURL, leopardCSSURL;
+
+    try {
+      leopardJSURL = String(new URL(fileJS, leopardURL));
+      leopardCSSURL = String(new URL(fileCSS, leopardURL));
+    } catch {
+      throw new Error(`Provided leopard-url isn't a valid URL base`);
+    }
+
+    return project.toLeopard({
+      leopardJSURL,
+      leopardCSSURL
+    });
   }
 
   switch (outputType) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -163,11 +163,13 @@ async function run() {
     }
   );
 
+  function toLeopard() {
+    return project.toLeopard();
+  }
+
   switch (outputType) {
     case "leopard": {
-      const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, () => {
-        return project.toLeopard();
-      });
+      const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, toLeopard);
 
       const fullOutputPath = path.resolve(process.cwd(), output);
 
@@ -240,10 +242,7 @@ async function run() {
       break;
     }
     case "leopard-zip": {
-      const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, () => {
-        const leopard = project.toLeopard();
-        return leopard;
-      });
+      const leopard = await writeStep(`${chalk.bold("Converting")} project to ${chalk.white("Leopard")}.`, toLeopard);
 
       const fullOutputPath = path.resolve(process.cwd(), output);
 


### PR DESCRIPTION
Enables testing a custom Leopard build locally, or providing any other alternate Leopard library host.

The default value is the same one that is used by default in [`toLeopard.ts`](https://github.com/leopard-js/sb-edit/blob/9b0f978422d8c0c55918267f7721ff00cb575453/src/io/leopard/toLeopard.ts#L405-L406). It would be nice not to duplicate this definition, but unless toLeopard defined it as an export (this would probably be awkward) or stops providing a default at all, it is what it is.

This option is used in both leopard and leopard-zip output formats, and ignored in other formats.

Only fully qualified URLs are supported, i.e. you can't just do `/leopard/dist`. This is to make the output folder work regardless where it's hosted (provided the specified URL is accessible there), and to avoid confusing a path on a hypothetical file server with a path on your own system.

There's no magic about e.g. taking a specified *path* to Leopard and copying out the dist/ files at time of `sb-edit` run (to make a self-contained folder/zip). That's out of scope for this PR, and may require adjustments to `toLeopard` internals (e.g. supporting relative imports there).

Typical development setup 1:

```sh
# terminal 1
cd leopard
npm run dev

# terminal 2
cd leopard/dist
npx vite --port 6201

# terminal 3
npx vite --port 6200

# terminal 4
sb-edit -i /path/to/proj.sb3 -o demo \
  --leopard-url http://localhost:6201/

# in browser, navigate to:
# http://localhost:6200/demo/
```

Typical development setup 2:

```sh
# terminal 1
cd leopard
npm run dev

# terminal 2
npx vite --port 6200

# terminal 3
rm -rf demo
sb-edit -i /path/to/proj.sb3 -o demo \
  --leopard-url http://localhost:6200/leopard/dist/

# in browser, navigate to:
# http://localhost:6200/demo/
```