### PR TITLE
toLeopard: Strict number casting

### DIFF
--- a/src/__tests__/__snapshots__/compilesb3.test.ts.snap
+++ b/src/__tests__/__snapshots__/compilesb3.test.ts.snap
@@ -266,7 +266,7 @@ export default class Stage extends StageBase {
       "thing"
     );
     this.vars.testList.splice(
-      this.itemOf(this.vars.testList, 0) - 1,
+      this.toNumber(this.itemOf(this.vars.testList, 0)) - 1,
       1,
       this.vars.testList.length
     );

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -2103,7 +2103,7 @@ export default function toLeopard(
 
         case OpCode.operator_mathop: {
           const num = inputToJS(block.inputs.NUM, InputShape.ZeroCastNumber);
-          const val = parseNumber(num);
+          const val = parseNumber(block.inputs.NUM);
 
           const isNotInfinity = typeof val === "number";
           const infinityIsNaN = isNotInfinity ? InputShape.ZeroCastNumber : InputShape.StrictlyCastNumber;

--- a/src/io/leopard/toLeopard.ts
+++ b/src/io/leopard/toLeopard.ts
@@ -2102,77 +2102,101 @@ export default function toLeopard(
         }
 
         case OpCode.operator_mathop: {
-          // TODO: Verify this is true for all ops.
-          satisfiesInputShape = InputShape.ZeroCastNumber;
-
           const num = inputToJS(block.inputs.NUM, InputShape.ZeroCastNumber);
+          const val = parseNumber(num);
+
+          const isNotInfinity = typeof val === "number";
+          const infinityIsNaN = isNotInfinity ? InputShape.ZeroCastNumber : InputShape.StrictlyCastNumber;
+
+          const isNotNegative = typeof val === "number" && val >= 0;
+          const negativeIsNaN = isNotNegative ? InputShape.ZeroCastNumber : InputShape.StrictlyCastNumber;
+
+          const magnitudeIsOneOrLower = typeof val === "number" && Math.abs(val) <= 1;
+          const magnitudeAboveOneIsNaN = magnitudeIsOneOrLower
+            ? InputShape.ZeroCastNumber
+            : InputShape.StrictlyCastNumber;
+
           switch (block.inputs.OPERATOR.value) {
             case "abs": {
+              satisfiesInputShape = InputShape.ZeroCastNumber;
               blockSource = `Math.abs(${num})`;
               break;
             }
 
             case "floor": {
+              satisfiesInputShape = InputShape.ZeroCastNumber;
               blockSource = `Math.floor(${num})`;
               break;
             }
 
             case "ceiling": {
+              satisfiesInputShape = InputShape.ZeroCastNumber;
               blockSource = `Math.ceil(${num})`;
               break;
             }
 
             case "sqrt": {
+              satisfiesInputShape = negativeIsNaN;
               blockSource = `Math.sqrt(${num})`;
               break;
             }
 
             case "sin": {
+              satisfiesInputShape = infinityIsNaN;
               blockSource = `Math.sin(this.degToRad(${num}))`;
               break;
             }
 
             case "cos": {
+              satisfiesInputShape = infinityIsNaN;
               blockSource = `Math.cos(this.degToRad(${num}))`;
               break;
             }
 
             case "tan": {
+              satisfiesInputShape = infinityIsNaN;
               blockSource = `this.scratchTan(${num})`;
               break;
             }
 
             case "asin": {
+              satisfiesInputShape = magnitudeAboveOneIsNaN;
               blockSource = `this.radToDeg(Math.asin(${num}))`;
               break;
             }
 
             case "acos": {
+              satisfiesInputShape = magnitudeAboveOneIsNaN;
               blockSource = `this.radToDeg(Math.acos(${num}))`;
               break;
             }
 
             case "atan": {
+              satisfiesInputShape = InputShape.ZeroCastNumber;
               blockSource = `this.radToDeg(Math.atan(${num}))`;
               break;
             }
 
             case "ln": {
+              satisfiesInputShape = negativeIsNaN;
               blockSource = `Math.log(${num})`;
               break;
             }
 
             case "log": {
+              satisfiesInputShape = negativeIsNaN;
               blockSource = `Math.log10(${num})`;
               break;
             }
 
             case "e ^": {
+              satisfiesInputShape = InputShape.ZeroCastNumber;
               blockSource = `Math.E ** ${num}`;
               break;
             }
 
             case "10 ^": {
+              satisfiesInputShape = InputShape.ZeroCastNumber;
               blockSource = `10 ** ${num}`;
               break;
             }


### PR DESCRIPTION
Resolves #123. Related to leopard-js/leopard-mentors#4 and #150.

This PR implements the proposal most particularly outlined in https://github.com/leopard-js/sb-edit/issues/123#issuecomment-1868418197. It's intended as an alternative, and probably lesser, option, compared to the "traits" system outlined in - well, the same comment ✨ - and we'd like to have a go at implementing that one, before merging this. However, both PRs should be equally effective in generally fixing issues to do with surprise NaN in converted projects. (That being the case, behavior-testing projects are much needed.)

We haven't looked into it in great detail yet, but it appears to - more or less - fix the behavior of the case project (leopard-js/leopard-mentors#4), which has code that apparently sets sprite sizes to NaN.

This code is from December 2023 and we haven't made any significant edits except for rebasing it onto current master.